### PR TITLE
Fix additional context properties lost in translated page

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -47,9 +47,9 @@ class VueI18n {
         createPage({
           path: path.join(`/${pathSegment}/`, route.path),
           component: route.component,
-          context: {
+          context: Object.assign(page.context, {
             locale:  `${locale}`
-          },
+          }),
           route:{
             meta: {
               locale:  `${locale}`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-i18n",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Gridsome plugin for i18n",
   "main": "gridsome.server.js",
   "repository": {


### PR DESCRIPTION
Creating page from base `gridsome.server.js` and using a context properties it will be lost in translated pages.  
```js
createPage({
  path: page.path,
  component: './src/templates/Page.vue',
  context: {
    id: page.id // this are not available in translated pages
  }
})
```
This because all context object is overridden when adding `locale` property. This PR fix this behaviour doing a merge from original page context.
