### PR TITLE
Add custom method to merge path parts

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -45,7 +45,7 @@ class VueI18n {
         // Create a page clone on a path with locale segment
         const pathSegment = this.options.pathAliases[locale] || locale
         createPage({
-          path: path.join(`/${pathSegment}/`, route.path),
+          path: this.mergePathParts(pathSegment, route.path),
           component: route.component,
           context: Object.assign({}, page.context, {
             locale:  `${locale}`
@@ -73,6 +73,39 @@ class VueI18n {
         }
       })
     }
+  }
+
+  /**
+   * Merge paths parts into one
+   * 
+   * @param {string} parts multiple arguments
+   * @returns {string}
+   */
+  mergePathParts() {
+    const pathParts = []
+    for (var i = 0; i < arguments.length; i++) {
+      let pathPart = arguments[i];
+      // skip home
+      if (pathPart === '/') {
+        continue
+      }
+      // clean leading slash
+      if (pathPart.endsWith('/')) {
+        pathPart = pathPart.substring(0, pathPart.length - 1)
+      }
+      // clean trailing slash
+      if (pathPart.startsWith('/')) {
+        pathPart = pathPart.substring(1, pathPart.length)
+      }
+      // check if remain somethings
+      pathParts.push(pathPart)
+    }
+    // defending from request to merge / and /
+    if (pathParts.length === 0) {
+      return '/'
+    }
+    // ensure leading and trailing slashes
+    return '/' + pathParts.join('/') + '/'
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-i18n",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-i18n",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Gridsome plugin for i18n",
   "main": "gridsome.server.js",
   "repository": {


### PR DESCRIPTION
Avoid using path package, it use backslash on Windows system. This fix add a method with a custom logic to avoid this behaviour.

PS: Made a try with [url.resolve](https://nodejs.org/api/url.html#url_url_resolve_from_to) but wasn't made for this and it does not have the desired effect