### PR TITLE
Fix context locale property not correctly set

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -47,7 +47,7 @@ class VueI18n {
         createPage({
           path: path.join(`/${pathSegment}/`, route.path),
           component: route.component,
-          context: Object.assign(page.context, {
+          context: Object.assign({}, page.context, {
             locale:  `${locale}`
           }),
           route:{
@@ -63,7 +63,7 @@ class VueI18n {
       createPage({
         path: oldPage.path,
         component: route.component,
-        context: Object.assign(oldPage.context || {}, {
+        context: Object.assign({}, oldPage.context || {}, {
           locale: this.options.defaultLocale
         }),
         route:{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridsome-plugin-i18n",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Gridsome plugin for i18n",
   "main": "gridsome.server.js",
   "repository": {


### PR DESCRIPTION
Seems PR #7 introduce a bug, now locale property is not correctly set: every page has the default language. 

To be honest I did not understand what's the main cause :disappointed: however it seems related to an implicit bind of the page object properties.