### PR TITLE
Add i18nOptions object for vue-i18n

### DIFF
--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -13,7 +13,8 @@ export default function (Vue, options, { appOptions, router, head }) {
   // Add VueI18n plugin to Vue instance
   Vue.use(VueI18n)
   const i18n = new VueI18n(Object.assign(options, {
-    locale: options.defaultLocale
+    locale: options.defaultLocale,
+    ...(appOptions.i18nOptions || {})
   }))
   appOptions.i18n = i18n
 


### PR DESCRIPTION
Hi! This was supposed to be an issue/feature request, but I just created a minimal PR since it might be more useful.

This is a very minimal commit to allow passing options to `vue-i18n`. In my case, I need to pass `dateTimeFormats` and `numberFormats`.

