### PR TITLE
feature: prevent path generation for default language when rewriteDefaultLanguage is false

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -82,6 +82,9 @@ class VueI18n {
       let componentPathFor404 = route.component;
 
       for (const locale of this.options.locales) {
+        if (!this.options.rewriteDefaultLanguage && locale === this.options.defaultLocale) {
+          continue
+        }
         const pathSegment = this.options.pathAliases[locale] || locale
         createPage({
           path: `/${pathSegment}/:slug+`,
@@ -149,6 +152,9 @@ class VueI18n {
 
     // Create a page clone on a path with locale segment
     for (const locale of this.options.locales) {
+      if (!this.options.rewriteDefaultLanguage && locale === this.options.defaultLocale) {
+        continue
+      }
       const pathSegment = this.options.pathAliases[locale] || locale
       this.pagesToGenerate.push({
         path: this.mergePathParts(pathSegment, options.path),


### PR DESCRIPTION
For a project I'm working on I needed the default language to not have the `/en/` path prefix. I checked how this is handled in Nuxt and there are these possible strategies:

```
- 'no_prefix': routes won't be prefixed
- 'prefix_except_default': add locale prefix for every locale except default
- 'prefix': add locale prefix for every locale
- 'prefix_and_default': add locale prefix for every locale and default
```

https://nuxt-community.github.io/nuxt-i18n/routing.html#strategy

This PR implements the `prefix_and_default` as the default, and also adds the option for `prefix_except_default`. 

Let me know how you feel about this implementation, I'm open to any change :) I was unsure if it should throw an error if the strategy name is invalid, or if it should just fallback to the default option (that's what I did).