### PR TITLE
Fix merge route meta

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -110,7 +110,7 @@ class VueI18n {
         }),
         route: {
           name: route.name ? `${route.name}__${locale}` : undefined,
-          meta: Object.assign({}, options.meta || {},{
+          meta: Object.assign({}, options.meta || {}, route.internal.meta || {}, {
             locale: `${locale}`
           })
         },
@@ -128,7 +128,7 @@ class VueI18n {
         }),
         route: {
           name: route.name,
-          meta: Object.assign({}, options.meta || {},{
+          meta: Object.assign({}, options.meta || {}, route.internal.meta || {}, {
             locale: this.options.defaultLocale
           })
         },


### PR DESCRIPTION
The variable `options.meta` it's always "undefined", need use route.internal.meta to get the real meta object of route of page.
I discovered that when i trying to correct an conflict with plugin [@gridsome/vue-remark](https://gridsome.org/plugins/@gridsome/vue-remark)
This plugin use route.meta of page to pass an function to render page