### PR TITLE
Fix context locale property not correctly set when using templates

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -47,23 +47,23 @@ class VueI18n {
       if (!routes) {
         return
       }
-      
+
       routes.forEach(customRoute => {
         customRoute.route = customRoute.route || {}
         customRoute.route.meta = customRoute.route.meta || {}
         customRoute.route.meta.locale = locale
-    
+
         customRoute.context = customRoute.context || {}
         customRoute.context.locale = locale
-    
+
         createPage(customRoute);
       })
-    
+
     })
 
     // Disallow the automatic creation of the localized routes
     if (this.options.enablePathGeneration === false) return;
-    
+
     // Create new pages
     for (const page of this.pagesToGenerate) {
       createPage(page)
@@ -142,7 +142,12 @@ class VueI18n {
     if (options.context.locale !== undefined) {
       return options
     }
-    options.context.locale = this.options.defaultLocale
+    options.context.locale =
+        (options &&
+            options.internal &&
+            options.internal.queryVariables &&
+            options.internal.queryVariables.locale) ||
+        this.options.defaultLocale
 
     // Retrieve current route
     const route = this.pages.getRoute(options.internal.route)
@@ -213,7 +218,10 @@ class VueI18n {
     }
 
     if (!meta.locale) {
-      options.internal.meta.locale = this.options.defaultLocale
+      const [locale] = options.path.match(
+          new RegExp(`\/${this.options.locales.join('/|/')}\/`)
+      ) || [this.options.defaultLocale]
+      options.internal.meta.locale = locale.replace(/\//g, '')
     }
 
     return options


### PR DESCRIPTION
This pull request **fixes the missing locale property when using templates**.

### Example

If you are using template paths in the Gridsome configuration to generate localized pages, e.g.

```js
module.exports = {
  templates: {
    ContentfulNews: [
      {
        path: (node) =>  `/${node.locale}/${node.locale === 'de' ? 'nachrichten' : 'news'}/${node.slug}`
      }
    ]
  }
}
```

Until now, `$context.locale` as well as `$route.meta.locale` were falling back to the default locale for each of these routes. 

### Reason

The reason for this problem is that **the default Gridsome template generation doesn't set any context variable, causing the plugin to fall back to the default**.

This happens for `$context.locale` 
https://github.com/daaru00/gridsome-plugin-i18n/blob/017f4eb02d5050ae5a2df1f5abbdd7fba9ad5716/gridsome.server.js#L145

as well as for `$route.meta.locale`
https://github.com/daaru00/gridsome-plugin-i18n/blob/017f4eb02d5050ae5a2df1f5abbdd7fba9ad5716/gridsome.server.js#L215-L217

### Fix

To set `$context.locale` I use the current node and search for a `locale` parameter. For `$route.meta.locale` there is no access to the node unfortunately, that's why I check if the locale appears in the current path.
