### PR TITLE
Persist hash when redirecting

### DIFF
--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -110,9 +110,12 @@ export default function (Vue, options, { appOptions, router, head }) {
       return next()
     }
 
+    const hash = to.hash || '';
+
     // Rewrite path
     next({
-      path: translatedPath
+      path: translatedPath,
+      hash
     })
   })
 


### PR DESCRIPTION
When visiting a URL with a hash (something formatted akin to https://gridsome.org/docs/dynamic-routing/#file-based-dynamic-routes), the hash gets stripped out when the path is updated to include the `/en` prefix. This simply passes the hash on (if it exists), allowing the browser to still navigate to the correct spot on the page after the redirect has taken place. 