### PR TITLE
Feature/skip pages where path is starting with locale already

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,37 @@ Enable path rewrite for default language.
 
 Enable translated path automatic generation. Disabling this no additional pages are generated, just include i18n Vue Plugin and let you to manage translated path generation.
 
+#### skipPagesStartingWithLocale
+
+- Type: `boolean`
+- Default: `false`
+
+Skips creating page clones per locale if the path already starts with a locale e.g. `/en/blog/foo` or `/de/blog/foo`
+
+This can be the case for gridsome templates which already contain a locale-prefix coming e.g. from a .md file where people maintain the language / locale themselves (e.g. in a frontmatter block with a "lang: en" flag)
+
+In this case those pages are already correct and can be skipped while still creating a locale-path for everything else.
+
+Example:
+
+```js
+// gridsome-config.js
+
+templates: {
+Post: [
+ {
+  path: (node) => {
+    return `/${node.lang}/blog/${node.slug}`
+  }
+ }
+],
+}
+```
+
+In this example the locale is take from ```node.lang``` which could come from a `.md` file when using `@gridsome/source-filesystem`
+
+This might be a corner-case flag, but useful if this plugin works for 90% of existing pages, but you have some exceptions, where you have maintained you locale yourself already.
+
 #### routes
 
 - Type: `object`

--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -26,7 +26,7 @@ class VueI18n {
        *  Post: [
           {
             path: (node) => {
-              return `/${node.lang}/c/${node.slug}`
+              return `/${node.lang}/blog/${node.slug}`
             }
           }
           ],


### PR DESCRIPTION
This PR suggests a new option `skipPagesStartingWithLocale` (default: false)

It  skips creating page clones per locale if the path already starts with a locale e.g. `/en/blog/foo` or `/de/blog/foo`

This can be the case for gridsome templates which already contain a locale-prefix coming e.g. from a .md file where people maintain the language / locale themselves (e.g. in a frontmatter block with a "lang: en" flag)

In this case those pages are already correct and can be skipped while still creating a locale-path for everything else.

## What problem does it solve?

Without this option this plugin will create double-prefix the locale to pages which already have a locale-prefix.
This leads to a deeply nested `/dist` folder where each locale contains the locale sub-folders again.

e.g. 
- /dist/de
- /dist/de/de
- /dist/de/en
- /dist/en
- /dist/en/de
- /dist/en/en

This increases the resulting /dist folder size a lot. It works technically, because all files are there and correct, but the dist folder is larger than needed which wastes build and deployment time.


Example:

```js
// gridsome-config.js

templates: {
Post: [
 {
  path: (node) => {
    return `/${node.lang}/blog/${node.slug}`
  }
 }
],
}
```

In this example the locale is take from ```node.lang``` which could come from a `.md` file when using `@gridsome/source-filesystem`.

Since template paths are different for every template / type, some could contain the locale, some not. 

This might be a corner-case flag, but useful if this plugin works for 90% of existing pages, but you have some exceptions, where you have maintained you locale yourself already.

## Just some background about our use case

We build a site using different datasources:
- @gridsome/source-filesystem
- @gridsome/vue-remark
- and some items from a remote REST-API via api.loadSource(({ addCollection }) and templates

Our templates in `gridsome.config.js` are:

```js
templates: {
    
    Tag: '/tag/:id',
    
    PostType: '/explore/:id',

    Post: [
      {
        path: (node) => {
          return `/${node.lang}/blog/${node.slug}`
        }
      }
    ],



    Addon: [
      {
        path: (node) => {
          return `/${node.lang}/addon/${node.slug}`
        }
      },
}
```

As you see some templates do have the `/${node.lang}` some have not. The latter work already fine with this plugin. 